### PR TITLE
correct --provider example

### DIFF
--- a/pages/getting-started.md
+++ b/pages/getting-started.md
@@ -339,10 +339,10 @@ If everything resolves correctly, the result is an `importmap.json` referencing 
 
 ### Using Other CDN Providers
 
-Alternatively, Lit can be loaded from another CDN like jsdelivr:
+Alternatively, Lit can be loaded from another CDN like UNPKG:
 
 ```
-jspm install --provider jsdelivr
+jspm install --provider unpkg
 ```
 
 Resulting in:


### PR DESCRIPTION
Updates --provider example to use "unpkg" instead of "jsdelivr" so that the command matches the example output.

closes #34 