### PR TITLE
fix: comments out body font-size on docs pages

### DIFF
--- a/public_html/docs/generator/dev/assets/style.css
+++ b/public_html/docs/generator/dev/assets/style.css
@@ -341,7 +341,7 @@ dd {
 body {
     background: var(--color-background);
     font-family: "Segoe UI", sans-serif;
-    font-size: 16px;
+    /* font-size: 16px; */
     color: var(--color-text);
 }
 

--- a/public_html/docs/generator/stable/assets/style.css
+++ b/public_html/docs/generator/stable/assets/style.css
@@ -341,7 +341,7 @@ dd {
 body {
     background: var(--color-background);
     font-family: "Segoe UI", sans-serif;
-    font-size: 16px;
+    /* font-size: 16px; */
     color: var(--color-text);
 }
 

--- a/public_html/docs/generator/v1.1.10/assets/style.css
+++ b/public_html/docs/generator/v1.1.10/assets/style.css
@@ -341,7 +341,7 @@ dd {
 body {
     background: var(--color-background);
     font-family: "Segoe UI", sans-serif;
-    font-size: 16px;
+    /* font-size: 16px; */
     color: var(--color-text);
 }
 

--- a/public_html/docs/generator/v1.1.12/assets/style.css
+++ b/public_html/docs/generator/v1.1.12/assets/style.css
@@ -341,7 +341,7 @@ dd {
 body {
     background: var(--color-background);
     font-family: "Segoe UI", sans-serif;
-    font-size: 16px;
+    /* font-size: 16px; */
     color: var(--color-text);
 }
 

--- a/public_html/docs/generator/v1.1.6/assets/style.css
+++ b/public_html/docs/generator/v1.1.6/assets/style.css
@@ -341,7 +341,7 @@ dd {
 body {
     background: var(--color-background);
     font-family: "Segoe UI", sans-serif;
-    font-size: 16px;
+    /* font-size: 16px; */
     color: var(--color-text);
 }
 

--- a/public_html/docs/generator/v1.1.9/assets/style.css
+++ b/public_html/docs/generator/v1.1.9/assets/style.css
@@ -341,7 +341,7 @@ dd {
 body {
     background: var(--color-background);
     font-family: "Segoe UI", sans-serif;
-    font-size: 16px;
+    /* font-size: 16px; */
     color: var(--color-text);
 }
 

--- a/public_html/docs/generator/v1.1/assets/style.css
+++ b/public_html/docs/generator/v1.1/assets/style.css
@@ -341,7 +341,7 @@ dd {
 body {
     background: var(--color-background);
     font-family: "Segoe UI", sans-serif;
-    font-size: 16px;
+    /* font-size: 16px; */
     color: var(--color-text);
 }
 

--- a/public_html/docs/generator/v2.0.0/assets/style.css
+++ b/public_html/docs/generator/v2.0.0/assets/style.css
@@ -341,7 +341,7 @@ dd {
 body {
     background: var(--color-background);
     font-family: "Segoe UI", sans-serif;
-    font-size: 16px;
+    /* font-size: 16px; */
     color: var(--color-text);
 }
 

--- a/public_html/docs/generator/v2.0/assets/style.css
+++ b/public_html/docs/generator/v2.0/assets/style.css
@@ -341,7 +341,7 @@ dd {
 body {
     background: var(--color-background);
     font-family: "Segoe UI", sans-serif;
-    font-size: 16px;
+    /* font-size: 16px; */
     color: var(--color-text);
 }
 

--- a/public_html/docs/import-map/dev/assets/style.css
+++ b/public_html/docs/import-map/dev/assets/style.css
@@ -341,7 +341,7 @@ dd {
 body {
     background: var(--color-background);
     font-family: "Segoe UI", sans-serif;
-    font-size: 16px;
+    /* font-size: 16px; */
     color: var(--color-text);
 }
 

--- a/public_html/docs/import-map/stable/assets/style.css
+++ b/public_html/docs/import-map/stable/assets/style.css
@@ -341,7 +341,7 @@ dd {
 body {
     background: var(--color-background);
     font-family: "Segoe UI", sans-serif;
-    font-size: 16px;
+    /* font-size: 16px; */
     color: var(--color-text);
 }
 

--- a/public_html/docs/import-map/v1.0.7/assets/style.css
+++ b/public_html/docs/import-map/v1.0.7/assets/style.css
@@ -341,7 +341,7 @@ dd {
 body {
     background: var(--color-background);
     font-family: "Segoe UI", sans-serif;
-    font-size: 16px;
+    /* font-size: 16px; */
     color: var(--color-text);
 }
 

--- a/public_html/docs/import-map/v1.0/assets/style.css
+++ b/public_html/docs/import-map/v1.0/assets/style.css
@@ -341,7 +341,7 @@ dd {
 body {
     background: var(--color-background);
     font-family: "Segoe UI", sans-serif;
-    font-size: 16px;
+    /* font-size: 16px; */
     color: var(--color-text);
 }
 

--- a/public_html/docs/jspm-cli/dev/assets/style.css
+++ b/public_html/docs/jspm-cli/dev/assets/style.css
@@ -341,7 +341,7 @@ dd {
 body {
     background: var(--color-background);
     font-family: "Segoe UI", sans-serif;
-    font-size: 16px;
+    /* font-size: 16px; */
     color: var(--color-text);
 }
 

--- a/public_html/docs/jspm-cli/stable/assets/style.css
+++ b/public_html/docs/jspm-cli/stable/assets/style.css
@@ -341,7 +341,7 @@ dd {
 body {
     background: var(--color-background);
     font-family: "Segoe UI", sans-serif;
-    font-size: 16px;
+    /* font-size: 16px; */
     color: var(--color-text);
 }
 

--- a/public_html/docs/jspm-cli/v3.0.0/assets/style.css
+++ b/public_html/docs/jspm-cli/v3.0.0/assets/style.css
@@ -341,7 +341,7 @@ dd {
 body {
     background: var(--color-background);
     font-family: "Segoe UI", sans-serif;
-    font-size: 16px;
+    /* font-size: 16px; */
     color: var(--color-text);
 }
 

--- a/public_html/docs/jspm-cli/v3.0.1/assets/style.css
+++ b/public_html/docs/jspm-cli/v3.0.1/assets/style.css
@@ -341,7 +341,7 @@ dd {
 body {
     background: var(--color-background);
     font-family: "Segoe UI", sans-serif;
-    font-size: 16px;
+    /* font-size: 16px; */
     color: var(--color-text);
 }
 

--- a/public_html/docs/jspm-cli/v3.0.2/assets/style.css
+++ b/public_html/docs/jspm-cli/v3.0.2/assets/style.css
@@ -341,7 +341,7 @@ dd {
 body {
     background: var(--color-background);
     font-family: "Segoe UI", sans-serif;
-    font-size: 16px;
+    /* font-size: 16px; */
     color: var(--color-text);
 }
 

--- a/public_html/docs/jspm-cli/v3.0/assets/style.css
+++ b/public_html/docs/jspm-cli/v3.0/assets/style.css
@@ -341,7 +341,7 @@ dd {
 body {
     background: var(--color-background);
     font-family: "Segoe UI", sans-serif;
-    font-size: 16px;
+    /* font-size: 16px; */
     color: var(--color-text);
 }
 

--- a/public_html/docs/jspm-cli/v3.1.2/assets/style.css
+++ b/public_html/docs/jspm-cli/v3.1.2/assets/style.css
@@ -341,7 +341,7 @@ dd {
 body {
     background: var(--color-background);
     font-family: "Segoe UI", sans-serif;
-    font-size: 16px;
+    /* font-size: 16px; */
     color: var(--color-text);
 }
 

--- a/public_html/docs/jspm-cli/v3.1/assets/style.css
+++ b/public_html/docs/jspm-cli/v3.1/assets/style.css
@@ -341,7 +341,7 @@ dd {
 body {
     background: var(--color-background);
     font-family: "Segoe UI", sans-serif;
-    font-size: 16px;
+    /* font-size: 16px; */
     color: var(--color-text);
 }
 

--- a/public_html/docs/jspm-cli/v3.2.0/assets/style.css
+++ b/public_html/docs/jspm-cli/v3.2.0/assets/style.css
@@ -341,7 +341,7 @@ dd {
 body {
     background: var(--color-background);
     font-family: "Segoe UI", sans-serif;
-    font-size: 16px;
+    /* font-size: 16px; */
     color: var(--color-text);
 }
 

--- a/public_html/docs/jspm-cli/v3.2/assets/style.css
+++ b/public_html/docs/jspm-cli/v3.2/assets/style.css
@@ -341,7 +341,7 @@ dd {
 body {
     background: var(--color-background);
     font-family: "Segoe UI", sans-serif;
-    font-size: 16px;
+    /* font-size: 16px; */
     color: var(--color-text);
 }
 


### PR DESCRIPTION
# Description

> _Observed_: there is a difference between font sizes on docs pages vs other pages.

---

![SCR-20240118-byku](https://github.com/jspm/jspm.org/assets/1074042/f3d137ee-e65b-45c4-bd1a-da247b2e61b1)

vs

![SCR-20240118-bzbf](https://github.com/jspm/jspm.org/assets/1074042/2baf9b18-545a-4d03-a4fc-0be67e4d85f7)

---

This PR provides a brute force update. Happy to re-implement!
