### PR TITLE
Fix curl command URLs in API documentation

### DIFF
--- a/pages/cdn/api.md
+++ b/pages/cdn/api.md
@@ -143,7 +143,7 @@ The response is a JSON file containing a `pkgUrl` and `files` list providing the
 ### Examples
 
 ```sh
-curl https://api.jspm.io/download?packages=jquery@3.7.1&provider=jspm.io
+curl https://api.jspm.io/download/?packages=jquery@3.7.1&provider=jspm.io
 ```
 
 Output:
@@ -175,7 +175,7 @@ Output:
 ```
 
 ```sh
-curl -X POST -d '{ "packages": ["jquery@3.7.1", "jquery@3.7.0"], "provider": "jsdelivr", "exclude": ["sourcemaps", "types", "unused"] }' https://api.jspm.io/download
+curl -X POST -d '{ "packages": ["jquery@3.7.1", "jquery@3.7.0"], "provider": "jsdelivr", "exclude": ["sourcemaps", "types", "unused"] }' https://api.jspm.io/download/
 ```
 
 Output:


### PR DESCRIPTION
Trailing slashes are required for `/download`